### PR TITLE
Use Concurent constraint instead of fs2.Compiler

### DIFF
--- a/client/src/main/scala/steve/client/BuildReader.scala
+++ b/client/src/main/scala/steve/client/BuildReader.scala
@@ -4,6 +4,7 @@ import fs2.io.file.Path
 import fs2.io.file.Files
 import cats.implicits.*
 import cats.MonadThrow
+import cats.effect.Concurrent
 import steve.Build
 
 trait BuildReader[F[_]] {
@@ -13,7 +14,7 @@ trait BuildReader[F[_]] {
 object BuildReader {
   def apply[F[_]](using F: BuildReader[F]): BuildReader[F] = F
 
-  def instance[F[_]: Files: MonadThrow](using fs2.Compiler[F, F]): BuildReader[F] =
+  def instance[F[_]: Files: Concurrent]: BuildReader[F] =
     buildFile =>
       Files[F]
         .readAll(buildFile)

--- a/client/src/main/scala/steve/client/BuildReader.scala
+++ b/client/src/main/scala/steve/client/BuildReader.scala
@@ -3,7 +3,6 @@ package steve.client
 import fs2.io.file.Path
 import fs2.io.file.Files
 import cats.implicits.*
-import cats.MonadThrow
 import cats.effect.Concurrent
 import steve.Build
 

--- a/client/src/main/scala/steve/client/ClientSideExecutor.scala
+++ b/client/src/main/scala/steve/client/ClientSideExecutor.scala
@@ -23,8 +23,6 @@ object ClientSideExecutor {
 
   def instance[F[_]: Http4sClientInterpreter: Sync: Logger](
     client: Client[F]
-  )(
-    using fs2.Compiler[F, F]
   ): Executor[F] =
     new Executor[F] {
 

--- a/client/src/main/scala/steve/client/Main.scala
+++ b/client/src/main/scala/steve/client/Main.scala
@@ -5,6 +5,7 @@ import cats.Functor
 import cats.effect.ExitCode
 import cats.effect.IO
 import cats.effect.Resource
+import cats.effect.Concurrent
 import cats.effect.kernel.Async
 import cats.implicits.*
 import com.monovore.decline.Opts
@@ -16,7 +17,6 @@ import sttp.tapir.client.http4s.Http4sClientInterpreter
 import steve.Command
 import steve.Executor
 import steve.OutputEvent
-import cats.MonadThrow
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
@@ -44,7 +44,7 @@ object Main extends CommandIOApp("steve", "Command line interface for Steve") {
     case CLICommand.List      => Command.ListImages.pure[F]
   }
 
-  def eval[F[_]: MonadThrow](exec: Executor[F])(using fs2.Compiler[F, F]): Command => F[String] = {
+  def eval[F[_]: Concurrent](exec: Executor[F]): Command => F[String] = {
     case Command.Build(build) =>
       // todo: pretty-print stream failures
       // todo: pretty-print errors in stream

--- a/shared/src/main/scala/steve/Executor.scala
+++ b/shared/src/main/scala/steve/Executor.scala
@@ -2,10 +2,10 @@ package steve
 
 import io.circe.Codec
 import sttp.tapir.Schema
-import cats.MonadThrow
 import cats.Eq
 import cats.implicits.*
 import cats.Functor
+import cats.effect.Concurrent
 
 //move to model
 enum OutputEvent[+A] derives Schema {
@@ -36,10 +36,8 @@ object OutputEvent {
 
     }
 
-  def getResult[F[_]: MonadThrow, A](
+  def getResult[F[_]: Concurrent, A](
     stream: fs2.Stream[F, OutputEvent[A]]
-  )(
-    using fs2.Compiler[F, F]
   ): F[A] =
     stream
       .collectFirst { case Result(a) => a }


### PR DESCRIPTION
As discuss here: https://github.com/http4s/http4s/pull/5206, using `fs2.Compiler` as a constraint is an anti pattern. Suggestion is to using `Concurrent` instead.